### PR TITLE
Fixed axes_names in MCS/MCS2, tested in v4

### DIFF
--- a/plugin_info.toml
+++ b/plugin_info.toml
@@ -11,5 +11,5 @@ license = 'MIT'
 
 [plugin-install]
 #packages required for your plugin:
-packages-required = ['instrumental-lib', 'pymodaq>=4.0.1']
+packages-required = ['instrumental-lib', 'pymodaq>=4.0.7']
 ##

--- a/src/pymodaq_plugins_smaract/daq_move_plugins/daq_move_SmarActMCS.py
+++ b/src/pymodaq_plugins_smaract/daq_move_plugins/daq_move_SmarActMCS.py
@@ -24,7 +24,7 @@ class DAQ_Move_SmarActMCS(DAQ_Move_base):
 
     is_multiaxes = True
     # we suppose to have a MCS controller with 3 channels (like the MCS-3D).
-    stage_names = [0, 1, 2]
+    axes_names= {'Axis 1': 0, 'Axis 2': 1, 'Axis 3': 2}
     # bounds corresponding to the SLC-24180
     min_bound = -61500  # µm
     max_bound = +61500  # µm
@@ -51,7 +51,7 @@ class DAQ_Move_SmarActMCS(DAQ_Move_base):
                 },
             ],
         },
-    ] + comon_parameters_fun(is_multiaxes, epsilon=_epsilon)
+    ] + comon_parameters_fun(is_multiaxes, axes_names, epsilon=_epsilon)
     ##########################################################
 
     def ini_attributes(self):

--- a/src/pymodaq_plugins_smaract/daq_move_plugins/daq_move_SmarActMCS2.py
+++ b/src/pymodaq_plugins_smaract/daq_move_plugins/daq_move_SmarActMCS2.py
@@ -35,7 +35,7 @@ class DAQ_Move_SmarActMCS2(DAQ_Move_base):
     is_multiaxes = True  # we suppose a have a MCS2 controller with a sensor
     # module for 3 channels (stages).
 
-    axes_names = [0, 1, 2]  # be careful that the channel index starts at 0
+    axes_names= {'Axis 1': 0, 'Axis 2': 1, 'Axis 3': 2}  # be careful that the channel index starts at 0
     # and not at 1 has is done in MCS2ServiceTool
 
     # bounds corresponding to the SLC-24180. Will be used at default if user doesn't provide other ones.


### PR DESCRIPTION
Now working in v4 with both MCS and MCS2 classes